### PR TITLE
tailscale: enable autodect of fw type

### DIFF
--- a/net/tailscale/files/tailscale.init
+++ b/net/tailscale/files/tailscale.init
@@ -23,6 +23,9 @@ start_service() {
   procd_open_instance
   procd_set_param command /usr/sbin/tailscaled
 
+  # starting with v1.48.1 ENV variable is required to enable autodetection of iptables / nftables
+  procd_set_param env TS_DEBUG_FIREWALL_MODE=auto
+
   # Set the port to listen on for incoming VPN packets.
   # Remote nodes will automatically be informed about the new port number,
   # but you might want to configure this in order to set external firewall


### PR DESCRIPTION
Maintainer: @ja-pa @oskarirauta
Compile tested: `aarch64_cortex-a53` @ SNAPSHOT
Run tested: `aarch64_cortex-a53` @ SNAPSHOT

Description:
